### PR TITLE
Complete Step Two of Coding Challenge

### DIFF
--- a/WordCountTool/FileProcessor.cs
+++ b/WordCountTool/FileProcessor.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace WordCountTool {
+﻿namespace WordCountTool {
     public class FileProcessor {
-        public static long GetByteCount(string filePath) => new FileInfo(filePath).Length;
+        public static long GetByteCount(string filePath) => File.ReadAllBytes(filePath).Length;
+
+        public static long GetLineCount(string filePath) => File.ReadAllLines(filePath).Length;
     }
 }

--- a/WordCountTool/Program.cs
+++ b/WordCountTool/Program.cs
@@ -2,7 +2,10 @@
 public class Program {
     static void Main(string[] args) {
         if (args.Length < 2 || args.Length % 2 != 0) {
-            Console.WriteLine("Usage: ccwc -c <file-path>");
+            Console.WriteLine("Usage: ccwc [-c <file-path>] [-l <file-path>]");
+            Console.WriteLine("\nExamples");
+            Console.WriteLine("  ccwc -c <file-path>\t# Outputs the number of bytes in the file");
+            Console.WriteLine("  ccwc -l <file-path>\t# Outputs the number of lines in the file");
             return;
         }
 
@@ -16,6 +19,17 @@ public class Program {
                         Console.WriteLine($"\t{FileProcessor.GetByteCount(filePath)} {filePath}");
                     } else {
                         Console.WriteLine("Error: Missing value for -c option.");
+                        return;
+                    }
+                    break;
+                // Output the number of lines in the file
+                case "-l":
+                    if (i + 1 < args.Length) {
+                        string? filePath = args[i + 1];
+                        i++;
+                        Console.WriteLine($"\t{FileProcessor.GetLineCount(filePath)} {filePath}");
+                    } else {
+                        Console.WriteLine("Error: Missing value for -l option.");
                         return;
                     }
                     break;

--- a/WordCountTool/Properties/launchSettings.json
+++ b/WordCountTool/Properties/launchSettings.json
@@ -6,6 +6,10 @@
     "Step1CountBytes": {
       "commandName": "Project",
       "commandLineArgs": "-c test.txt"
+    },
+    "Step2CountLines": {
+      "commandName": "Project",
+      "commandLineArgs": "-l test.txt"
     }
   }
 }

--- a/WordCountToolTests/FileProcessorTests.cs
+++ b/WordCountToolTests/FileProcessorTests.cs
@@ -11,5 +11,13 @@ namespace WordCountToolTests {
             // assert
             Assert.That(result, Is.EqualTo(342190));
         } 
+
+        [Test]
+        public void CanOutputLinesInAFile() {
+            // act
+            var result = FileProcessor.GetLineCount(TestFile);
+            // assert
+            Assert.That(result, Is.EqualTo(7145));
+        }
     }
 }


### PR DESCRIPTION
Accept the command line option of `-l`, which will output the number of lines for the given file path.

Remove unused file references in `FileProcessor.cs`, and update `GetByteCount()` to use the same library as `GetLineCount().